### PR TITLE
Add threads library to ujson_test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,11 @@
 # ujson
 
+find_package(Threads)
+
 add_executable(ujson_test test.cpp)
 set_target_properties(ujson_test PROPERTIES FOLDER "ujson")
 target_link_libraries(ujson_test ujson)
+target_link_libraries(ujson_test ${CMAKE_THREAD_LIBS_INIT})
 add_test(ujson_unit_test ujson_test)
 
 add_executable(ujson_fuzz fuzz.cpp)


### PR DESCRIPTION
When building on Fedora Linux 30, ujson_test link fails with the
following error:

  /usr/bin/ld: CMakeFiles/ujson_test.dir/test.cpp.o: in function `std::thread::thread<std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<____C_A_T_C_H____T_E_S_T____836()::{lambda()#1}> >, void>::_Async_state_impl(std::tuple<____C_A_T_C_H____T_E_S_T____836()::{lambda()#1}>&&)::{lambda()#1}, , void>(std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<____C_A_T_C_H____T_E_S_T____836()::{lambda()#1}> >, void>::_Async_state_impl(std::tuple<____C_A_T_C_H____T_E_S_T____836()::{lambda()#1}>&&)::{lambda()#1}&&)':
test.cpp:(.text+0x1b51f): undefined reference to `pthread_create'
  collect2: error: ld returned 1 exit status

Let's add the CMake's threads library (which maps to "-lpthread") to
ujson_test to fix linking on Linux.